### PR TITLE
Match multiple compile statements #2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-to-vec"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Joe Grund <joe.grund@intel.com>"]
 keywords = ["test", "cargo"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,7 @@
 extern crate nom;
 use std::str;
 
-use nom::{
-    line_ending,
-    digit,
-    space
-};
+use nom::{line_ending, digit, space};
 
 named!(
     rest_of_line<&str>,
@@ -21,8 +17,8 @@ named!(
 );
 
 named!(
-    compiling_opt<Option<()> >,
-    opt!(
+    compiling<Vec<()> >,
+    many0!(
         do_parse!(
             ws!(tag!("Compiling")) >>
             rest_of_line >>
@@ -81,7 +77,7 @@ named!(
 pub struct Test<'a, 'b, 'c> {
     pub name: &'a str,
     pub status: &'b str,
-    pub error:Option<&'c str>
+    pub error: Option<&'c str>,
 }
 
 named!(
@@ -123,12 +119,12 @@ named!(
 
 #[derive(Debug, PartialEq)]
 pub struct SuiteResult<'a> {
-  pub state: &'a str,
-  pub passed: i64,
-  pub failed: i64,
-  pub ignored: i64,
-  pub total: i64,
-  pub measured: i64
+    pub state: &'a str,
+    pub passed: i64,
+    pub failed: i64,
+    pub ignored: i64,
+    pub total: i64,
+    pub measured: i64,
 }
 
 named!(
@@ -172,8 +168,8 @@ named!(
 
 #[derive(Debug, PartialEq)]
 pub struct Failure<'a, 'b> {
-    pub name:&'a str,
-    pub error:&'b str
+    pub name: &'a str,
+    pub error: &'b str,
 }
 
 named!(
@@ -219,48 +215,45 @@ pub struct Suite<'a, 'b, 'c, 'd, 'e> {
     pub ignored: i64,
     pub measured: i64,
     pub total: i64,
-    pub tests: Vec<Test<'c, 'd, 'e>>
+    pub tests: Vec<Test<'c, 'd, 'e>>,
 }
 
-fn find_message_by_name <'a, 'b> (name:&str, failures:&Vec<Failure<'a, 'b>>) -> Option<&'b str> {
-  failures
-    .iter()
-    .find(|x| x.name == name)
-    .map(|x| x.error)
+fn find_message_by_name<'a, 'b>(name: &str, failures: &Vec<Failure<'a, 'b>>) -> Option<&'b str> {
+    failures.iter()
+        .find(|x| x.name == name)
+        .map(|x| x.error)
 }
 
-fn handle_parsed_suite <'a, 'b, 'c, 'd, 'e> (
-  name:&'a str,
-  tests:Vec<Test<'c, 'd, 'e>>,
-  failures:Option<Vec<Failure<'e, 'e>>>,
-  result:SuiteResult<'b>
-) -> Suite<'a, 'b, 'c, 'd, 'e> {
-  let tests_with_failures = match failures {
-    Some(xs) => {
-      tests
-      .iter()
-      .map(|t|
-        Test{
-          error: find_message_by_name(t.name, &xs),
-          name: t.name,
-          status: t.status
+fn handle_parsed_suite<'a, 'b, 'c, 'd, 'e>(name: &'a str,
+                                           tests: Vec<Test<'c, 'd, 'e>>,
+                                           failures: Option<Vec<Failure<'e, 'e>>>,
+                                           result: SuiteResult<'b>)
+                                           -> Suite<'a, 'b, 'c, 'd, 'e> {
+    let tests_with_failures = match failures {
+        Some(xs) => {
+            tests.iter()
+                .map(|t| {
+                    Test {
+                        error: find_message_by_name(t.name, &xs),
+                        name: t.name,
+                        status: t.status,
+                    }
+                })
+                .collect()
         }
-      )
-      .collect()
-    },
-    None => tests
-  };
+        None => tests,
+    };
 
-  Suite {
-      name: name,
-      tests: tests_with_failures,
-      state: result.state,
-      total: result.total,
-      passed: result.passed,
-      failed: result.failed,
-      ignored: result.ignored,
-      measured: result.measured
-  }
+    Suite {
+        name: name,
+        tests: tests_with_failures,
+        state: result.state,
+        total: result.total,
+        passed: result.passed,
+        failed: result.failed,
+        ignored: result.ignored,
+        measured: result.measured,
+    }
 }
 
 named!(
@@ -283,7 +276,7 @@ named!(
 named!(
     pub cargo_test_result_parser<Vec<Suite > >,
     do_parse!(
-        compiling_opt >>
+        compiling >>
         finished >>
         suites: suites_parser >>
         (suites)
@@ -293,128 +286,84 @@ named!(
 
 #[cfg(test)]
 mod parser_tests {
-  use nom::IResult;
-  use std::fmt::Debug;
-  use super::{
-      compiling_opt,
-      finished,
-      suite_line,
-      suite_count,
-      ok_or_failed,
-      Test,
-      test_result,
-      test_results,
-      digits,
-      suite_result,
-      SuiteResult,
-      cargo_test_result_parser,
-      Suite,
-      fail_line,
-      failure,
-      Failure,
-      failures
-  };
+    use nom::IResult;
+    use std::fmt::Debug;
+    use super::{compiling, finished, suite_line, suite_count, ok_or_failed, Test, test_result,
+                test_results, digits, suite_result, SuiteResult, cargo_test_result_parser, Suite,
+                fail_line, failure, Failure, failures};
 
-  fn assert_done<R:PartialEq + Debug>(l:IResult<&[u8], R>, r:R) {
-      assert_eq!(
+    fn assert_done<R: PartialEq + Debug>(l: IResult<&[u8], R>, r: R) {
+        assert_eq!(
           l,
           IResult::Done(&b""[..], r)
       )
-  }
+    }
 
-  #[test]
-  fn it_should_match_a_compiler_line() {
-      let output = &b"   Compiling docker-command v0.1.0 (file:///Users/joegrund/projects/docker-command-rs)
+    #[test]
+    fn it_should_match_a_compiler_line() {
+        let output = &b"   Compiling docker-command v0.1.0 (file:///Users/joegrund/projects/docker-command-rs)
 "[..];
 
-      assert_done(
-          compiling_opt(output),
-          Some(())
-      );
-  }
+        assert_done(compiling(output), vec![()]);
+    }
 
-  #[test]
-  fn it_should_parse_finish_line() {
-      let result = finished(
-          &b"    Finished debug [unoptimized + debuginfo] target(s) in 0.0 secs
-"[..]
-      );
+    #[test]
+    fn it_should_parse_finish_line() {
+        let result = finished(&b"    Finished debug [unoptimized + debuginfo] target(s) in 0.0 secs
+"[..]);
 
-      assert_done(
-          result,
-          ()
-      );
-  }
+        assert_done(result, ());
+    }
 
-  #[test]
-  fn it_should_parse_suite_line() {
-      let result = suite_line(
-          &b"Running target/debug/deps/docker_command-be014e20fbd07382
-"[..]
-      );
+    #[test]
+    fn it_should_parse_suite_line() {
+        let result = suite_line(&b"Running target/debug/deps/docker_command-be014e20fbd07382
+"[..]);
 
-      assert_done(
-          result,
-          "target/debug/deps/docker_command-be014e20fbd07382"
-      );
-  }
+        assert_done(result, "target/debug/deps/docker_command-be014e20fbd07382");
+    }
 
-  #[test]
-  fn it_should_parse_suite_count() {
-      let result = suite_count(
-          &b"running 0 tests
-"[..]
-      );
+    #[test]
+    fn it_should_parse_suite_count() {
+        let result = suite_count(&b"running 0 tests
+"[..]);
 
-      assert_done(result, ());
-  }
+        assert_done(result, ());
+    }
 
-  #[test]
-  fn it_should_match_ok() {
-      assert_done(
-        ok_or_failed(&b"ok"[..]),
-        "pass"
-      );
-  }
+    #[test]
+    fn it_should_match_ok() {
+        assert_done(ok_or_failed(&b"ok"[..]), "pass");
+    }
 
-  #[test]
-  fn it_should_match_failed() {
-      assert_done(
-        ok_or_failed(&b"FAILED"[..]),
-        "fail"
-      );
-  }
+    #[test]
+    fn it_should_match_failed() {
+        assert_done(ok_or_failed(&b"FAILED"[..]), "fail");
+    }
 
-  #[test]
-  fn it_should_parse_test_result() {
-      let result = test_result(
-          &b"test it_runs_a_command ... ok"[..]
-      );
+    #[test]
+    fn it_should_parse_test_result() {
+        let result = test_result(&b"test it_runs_a_command ... ok"[..]);
 
-      assert_done(
-          result,
-          Test {
-              name: "it_runs_a_command",
-              status: "pass",
-              error: None
-          }
-      );
-  }
+        assert_done(result,
+                    Test {
+                        name: "it_runs_a_command",
+                        status: "pass",
+                        error: None,
+                    });
+    }
 
-  #[test]
-  fn it_should_parse_test_results() {
-      let result = test_results(
-        &b"test tests::it_should_parse_first_line ... ok
+    #[test]
+    fn it_should_parse_test_results() {
+        let result = test_results(&b"test tests::it_should_parse_first_line ... ok
 test tests::it_should_parse_a_status_line ... ok
 test tests::it_should_parse_test_output ... ok
 test tests::it_should_parse_suite_line ... FAILED
-"[..]
-);
+"[..]);
 
-      assert_done(
-          result,
+        assert_done(result,
 
-              vec![
+                    vec![
                 Test {
                     name: "tests::it_should_parse_first_line",
                     status: "pass",
@@ -435,33 +384,28 @@ test tests::it_should_parse_suite_line ... FAILED
                     status: "fail",
                     error: None
                 }
-              ]
-      );
-  }
+              ]);
+    }
 
     #[test]
     fn it_should_capture_digits() {
-        assert_done(
-            digits(b"10"),
-            10
-        );
+        assert_done(digits(b"10"), 10);
     }
 
     #[test]
     fn it_should_parse_a_suite_result() {
-      let result = suite_result(&b"test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured"[..]);
+        let result =
+            suite_result(&b"test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured"[..]);
 
-      assert_done(
-        result,
-        SuiteResult {
-            state: "fail",
-            passed: 3,
-            failed: 1,
-            ignored: 0,
-            total: 4,
-            measured: 0,
-        }
-      );
+        assert_done(result,
+                    SuiteResult {
+                        state: "fail",
+                        passed: 3,
+                        failed: 1,
+                        ignored: 0,
+                        total: 4,
+                        measured: 0,
+                    });
     }
 
     #[test]
@@ -477,11 +421,10 @@ test tests::it_should_parse_first_line ... ok
   test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured
   "[..];
 
-      let result = cargo_test_result_parser(output);
+        let result = cargo_test_result_parser(output);
 
-      assert_done(
-        result,
-        vec![Suite {
+        assert_done(result,
+                    vec![Suite {
             name: "target/debug/cargo_test_junit-83252957c74e106d",
             state: "pass",
             tests: vec![
@@ -501,18 +444,14 @@ test tests::it_should_parse_first_line ... ok
             ignored: 0,
             measured: 0,
             total: 2
-        }]
-      );
+        }]);
     }
 
     #[test]
     fn test_fail_line() {
         let output = b"---- fail stdout ----";
 
-        assert_done(
-            fail_line(output),
-            "fail"
-        );
+        assert_done(fail_line(output), "fail");
     }
 
     #[test]
@@ -522,13 +461,12 @@ test tests::it_should_parse_first_line ... ok
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 ";
-        assert_done(
-            failure(output),
-            Failure {
-                name: "fail",
-                error: "thread 'fail' panicked at 'assertion failed: `(left == right)` (left: `1`, right: `2`)', tests/integration_test.rs:16"
-            }
-        );
+        assert_done(failure(output),
+                    Failure {
+                        name: "fail",
+                        error: "thread 'fail' panicked at 'assertion failed: `(left == right)` \
+                                (left: `1`, right: `2`)', tests/integration_test.rs:16",
+                    });
     }
 
     #[test]
@@ -595,10 +533,8 @@ error: test failed";
 
         let x = match cargo_test_result_parser(output) {
             IResult::Done(_, x) => x,
-            _ => panic!("BOOM!")
+            _ => panic!("BOOM!"),
         };
-
-        println!("{:#?}", x);
 
         assert_eq!(
             x,
@@ -641,5 +577,72 @@ error: test failed";
                 }
             ]
         );
+    }
+
+    #[test]
+    fn test_success_run() {
+        let output = b"   Compiling rustc-serialize v0.3.22
+   Compiling toml v0.2.1
+   Compiling pre-commit v0.5.2
+   Compiling foo v0.1.0 (file:///foo)
+    Finished debug [unoptimized + debuginfo] target(s) in 12.11 secs
+     Running target/debug/deps/foo-5a7be5d1b9c8e0f6
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+
+     Running target/debug/integration_test-283604d1063344ba
+
+running 1 test
+test it_runs_a_command ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+
+   Doc-tests foo
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured";
+
+        assert_done(cargo_test_result_parser(output),
+                    vec![
+                      Suite {
+                          name: "target/debug/deps/foo-5a7be5d1b9c8e0f6",
+                          state: "pass",
+                          passed: 0,
+                          failed: 0,
+                          ignored: 0,
+                          measured: 0,
+                          total: 0,
+                          tests: vec![]
+                      },
+                      Suite {
+                          name: "target/debug/integration_test-283604d1063344ba",
+                          state: "pass",
+                          passed: 1,
+                          failed: 0,
+                          ignored: 0,
+                          measured: 0,
+                          total: 1,
+                          tests: vec![
+                              Test {
+                                  name: "it_runs_a_command",
+                                  status: "pass",
+                                  error: None
+                              }
+                          ]
+                      },
+                      Suite {
+                          name: "foo",
+                          state: "pass",
+                          passed: 0,
+                          failed: 0,
+                          ignored: 0,
+                          measured: 0,
+                          total: 0,
+                          tests: vec![]
+                      }
+                  ]);
     }
 }


### PR DESCRIPTION
Fixes #2.

Cargo test output can have multiple compile statements. Currently we are only matching on 0 or 1 statements.

Instead we need to match on 0 - n.