### PR TITLE
Parse Downloads and Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-to-vec"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Joe Grund <joe.grund@intel.com>"]
 keywords = ["test", "cargo"]
 license = "MIT"


### PR DESCRIPTION
If tests are running for the first time, (which they would likely be in a clean-room CI env), the parser will fail on updating crates.io + downloading deps.

Make sure we parse these lines.

In addition, the test result line has a filtered out clause, so parse that as well.